### PR TITLE
Add 'host-network' option and cleanup

### DIFF
--- a/pkg/proxy/controllers/pod.go
+++ b/pkg/proxy/controllers/pod.go
@@ -350,6 +350,13 @@ func (pct *PodChangeTracker) newPodInfo(pod *v1.Pod) (*PodInfo, error) {
 
 // NewPodChangeTracker ...
 func NewPodChangeTracker(runtime RuntimeKind, runtimeEndpoint, hostname, hostPrefix string) *PodChangeTracker {
+	if runtimeEndpoint == "" {
+		return &PodChangeTracker{
+			items:     make(map[types.NamespacedName]*podChange),
+			hostname:  hostname,
+		}
+	}
+
 	switch runtime {
 	case Cri:
 		return NewPodChangeTrackerCri(runtimeEndpoint, hostname, hostPrefix)

--- a/pkg/proxy/server/iptables.go
+++ b/pkg/proxy/server/iptables.go
@@ -30,7 +30,6 @@ import (
 	"github.com/k8snetworkplumbingwg/multus-service/pkg/proxy/controllers"
 	"github.com/vishvananda/netlink"
 
-	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"k8s.io/klog"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
@@ -202,7 +201,7 @@ func (ipt *iptableBuffer) CreateNATChain(chainName string) bool {
 	return true
 }
 
-func (ipt *iptableBuffer) generateServiceEndpointSliceForwardingRules(s *Server, svcPortName *controllers.ServicePortName, svcInfo *controllers.ServicePortInfo, status *netdefv1.NetworkStatus) error {
+func (ipt *iptableBuffer) generateServiceEndpointSliceForwardingRules(s *Server, svcPortName *controllers.ServicePortName, svcInfo *controllers.ServicePortInfo, status *controllers.InterfaceInfo) error {
 	endpoints, ok := s.endpointsMap[*svcPortName]
 	if !ok {
 		return fmt.Errorf("not found: %s", svcInfo.Name)
@@ -241,12 +240,12 @@ func (ipt *iptableBuffer) generateServiceEndpointSliceForwardingRules(s *Server,
 	return nil
 }
 
-func (ipt *iptableBuffer) generateServicePortForwardingRules(s *Server, svcPortName *controllers.ServicePortName, svcInfo *controllers.ServicePortInfo, status *netdefv1.NetworkStatus) error {
+func (ipt *iptableBuffer) generateServicePortForwardingRules(s *Server, svcPortName *controllers.ServicePortName, svcInfo *controllers.ServicePortInfo, status *controllers.InterfaceInfo) error {
 
 	clusterIP := fmt.Sprintf("%s/32", svcInfo.ClusterIP)
 	if ipt.CreateNATChain(svcInfo.ChainName) {
 		// This iptables rule is new rule to be added, hence add clusterIP into NewClusterIPs
-		dev, err := netlink.LinkByName(status.Interface)
+		dev, err := netlink.LinkByName(status.InterfaceName)
 		if err != nil {
 			return err
 		}

--- a/pkg/proxy/server/options.go
+++ b/pkg/proxy/server/options.go
@@ -37,6 +37,7 @@ type Options struct {
 	containerRuntime         controllers.RuntimeKind
 	containerRuntimeEndpoint string
 	podIptables              string
+	hostNetwork              string
 	// errCh is the channel that errors will be sent
 	errCh chan error
 	// stopCh is used to stop the command
@@ -48,12 +49,14 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	klog.InitFlags(nil)
 	fs.SortFlags = false
 	fs.Var(&o.containerRuntime, "container-runtime", "Container runtime using for the cluster. Possible values: 'cri'. ")
-	fs.StringVar(&o.containerRuntimeEndpoint, "container-runtime-endpoint", o.containerRuntimeEndpoint, "Path to cri socket.")
-	fs.StringVar(&o.Kubeconfig, "kubeconfig", o.Kubeconfig, "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
-	fs.StringVar(&o.master, "master", o.master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
-	fs.StringVar(&o.hostnameOverride, "hostname-override", o.hostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
-	fs.StringVar(&o.hostPrefix, "host-prefix", o.hostPrefix, "If non-empty, will use this string as prefix for host filesystem.")
-	fs.StringVar(&o.podIptables, "pod-iptables", o.podIptables, "If non-empty, will use this path to store pod's iptables for troubleshooting helper.")
+	fs.StringVar(&o.containerRuntimeEndpoint, "container-runtime-endpoint", "", "Path to cri socket.")
+	fs.StringVar(&o.hostnameOverride, "hostname-override", "", "If non-empty, will use this string as identification instead of the actual hostname.")
+	//example: ./multus-proxy --host-network namespace/net-attach-def:eth1
+	fs.StringVar(&o.hostNetwork, "host-network", "", "If non-empty, configure iptable rules in host network namespace (arg: <net-attach-def>:<interface>).")
+	fs.StringVar(&o.hostPrefix, "host-prefix", "", "If non-empty, will use this string as prefix for host filesystem.")
+	fs.StringVar(&o.Kubeconfig, "kubeconfig", "", "Path to kubeconfig file with authorization information (the master location is set by the master flag).")
+	fs.StringVar(&o.master, "master", "", "The address of the Kubernetes API server (overrides any value in kubeconfig)")
+	fs.StringVar(&o.podIptables, "pod-iptables", "", "If non-empty, will use this path to store pod's iptables for troubleshooting helper.")
 	fs.AddGoFlagSet(flag.CommandLine)
 }
 


### PR DESCRIPTION
This change introduces 'host-network' option to support run multus-proxy in container host. This also cleanup the unused Docker client code.